### PR TITLE
Reputation System & more

### DIFF
--- a/EcoCompaniesMod/CompaniesPlugin.cs
+++ b/EcoCompaniesMod/CompaniesPlugin.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Reflection;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Eco.Server;
 
 
@@ -97,8 +98,11 @@ namespace Eco.Mods.Companies
                     CompanyManager.Obj.InterceptReputationTransfer(transferTransferAction, ref result);
                     if (result.Success) // update both sides if we had success
                     {
-                        Company.GetEmployer(transferTransferAction.ReputationSender)?.UpdateLegalPersonReputation();
-                        Company.GetEmployer(transferTransferAction.ReputationReceiver)?.UpdateLegalPersonReputation();
+                        Task.Delay(1000).ContinueWith((t) => // wait for ticks
+                        {
+                            Company.GetEmployer(transferTransferAction.ReputationSender)?.UpdateLegalPersonReputation();
+                            Company.GetEmployer(transferTransferAction.ReputationReceiver)?.UpdateLegalPersonReputation();
+                        });
                     }
                     break;
             }

--- a/EcoCompaniesMod/CompaniesPlugin.cs
+++ b/EcoCompaniesMod/CompaniesPlugin.cs
@@ -44,6 +44,12 @@ namespace Eco.Mods.Companies
     {
         [LocDescription("If enabled, employees may not have homestead deeds, and the company gets a HQ homestead deed that grows based on employee count.")]
         public bool PropertyLimitsEnabled { get; set; } = true;
+
+        [LocDescription("If enabled, employees can't give reputation to each other - reputation to legal person is denied at any case.")]
+        public bool CompanyReputationInterceptionEnabled { get; set; } = false;
+
+        [LocDescription("If enabled, the average repuation from all employees will be given to the legal person.")]
+        public bool ReputationAveragesEnabled { get; set; } = false;
     }
 
     [Serialized]
@@ -86,6 +92,9 @@ namespace Eco.Mods.Companies
                     break;
                 case PlaceOrPickUpObject placeOrPickupObjectAction:
                     CompanyManager.Obj.InterceptPlaceOrPickupObjectGameAction(placeOrPickupObjectAction, ref result);
+                    break;
+                case ReputationTransfer transferTransferAction: // intercepts new reputation actions
+                    CompanyManager.Obj.InterceptReputationTransfer(transferTransferAction, ref result);
                     break;
             }
             return result;

--- a/EcoCompaniesMod/CompaniesPlugin.cs
+++ b/EcoCompaniesMod/CompaniesPlugin.cs
@@ -95,6 +95,11 @@ namespace Eco.Mods.Companies
                     break;
                 case ReputationTransfer transferTransferAction: // intercepts new reputation actions
                     CompanyManager.Obj.InterceptReputationTransfer(transferTransferAction, ref result);
+                    if (result.Success) // update both sides if we had success
+                    {
+                        Company.GetEmployer(transferTransferAction.ReputationSender)?.UpdateLegalPersonReputation();
+                        Company.GetEmployer(transferTransferAction.ReputationReceiver)?.UpdateLegalPersonReputation();
+                    }
                     break;
             }
             return result;

--- a/EcoCompaniesMod/Company.cs
+++ b/EcoCompaniesMod/Company.cs
@@ -60,7 +60,10 @@ namespace Eco.Mods.Companies
     {
         private bool inReceiveMoney, inGiveMoney;
 
-        public static Company GetEmployer(User user)
+		public static bool IsInvited(User user, Company company)
+			=> company.InviteList.Contains(user);
+
+		public static Company GetEmployer(User user)
             => Registrars.Get<Company>().Where(x => x.IsEmployee(user)).SingleOrDefault();
 
         public static Company GetFromLegalPerson(User user)
@@ -911,7 +914,7 @@ namespace Eco.Mods.Companies
             deed.Accessors.Set(AllEmployees);
             if (deed == HQDeed)
             {
-                deed.Residency.Invitations.InvitationList.Set(AllEmployees);
+                deed.Residency.Invitations.InvitationList.Set(AllEmployees.Where(x => !deed.Residency.Residents.Contains(x)));
                 deed.Residency.AllowPlotsUnclaiming = true;
             }
             deed.MarkDirty();

--- a/EcoCompaniesMod/CompanyCommands.cs
+++ b/EcoCompaniesMod/CompanyCommands.cs
@@ -3,6 +3,8 @@ using System.Linq;
 
 namespace Eco.Mods.Companies
 {
+	using Eco.Core.Systems;
+
     using Shared.Localization;
     using Shared.Utils;
 
@@ -89,7 +91,49 @@ namespace Eco.Mods.Companies
             }
         }
 
-        [ChatSubCommand("Company", "Removes an employee from your company.", ChatAuthorizationLevel.User)]
+		[ChatSubCommand("Company", "Rejects an invitation for you to a company.", ChatAuthorizationLevel.User)]
+		public static void Reject(User user, Company targetCompany)
+		{
+            if (targetCompany.InviteList.Remove(user))
+            {
+				targetCompany.SendCompanyMessage(Localizer.Do($"{user.UILink()} has declined the invitation to join the company.")); 
+                user.OkBoxLoc($"You reject the invitation to {targetCompany.UILink()}");
+			} else
+            {
+				user.OkBoxLoc($"You aren't invited invitation to {targetCompany.UILink()}");
+			}
+		}
+
+		[ChatSubCommand("Company", "Rejects an invitation for you to a company.", ChatAuthorizationLevel.User)]
+		public static void Invites(User user)
+		{
+			var company = Companies.Company.GetEmployer(user);
+            if (company != null) { return;  }
+
+            var sb = new LocStringBuilder();
+
+			foreach (var cCompany in Registrars.Get<Company>().All())
+            {
+                if (cCompany.InviteList.Contains(user))
+                {
+                    if(!sb.ToString().IsSet())
+                    {
+						sb.AppendLineLoc($"Your are invite to these companies:\n\n");
+					}
+
+                    sb.AppendLine(new LocString($"{cCompany.UILink()} managed by {cCompany.Ceo.UILinkNullSafe()}"));
+                }
+            }
+
+			if (!sb.ToString().IsSet())
+			{
+				sb.AppendLineLoc($"Your aren't invited any company.") ;
+			}
+
+			user.OkBox(sb.ToLocString());
+		}
+
+		[ChatSubCommand("Company", "Removes an employee from your company.", ChatAuthorizationLevel.User)]
         public static void Fire(User user, User otherUser)
         {
             var company = Companies.Company.GetEmployer(user);
@@ -126,7 +170,6 @@ namespace Eco.Mods.Companies
             if (!currentEmployer.TryLeave(user, out var errorMessage))
             {
                 user.OkBox(errorMessage);
-                return;
             }
         }
 
@@ -288,6 +331,31 @@ namespace Eco.Mods.Companies
             }
         }
 
+        [ChatSubCommand("Company", "Provides admin-only options for company mod management.", ChatAuthorizationLevel.Admin)]
+        public static void Configure(User user, string verb, bool value)
+        {
+
+            switch (verb)
+            {
+                case "propertyLimits":
+                    CompaniesPlugin.Obj.Config.PropertyLimitsEnabled = value;
+                    user.MsgLoc($"propertyLimitsEnabled => {value}");
+                    break;
+                case "reputationAverages":
+                    CompaniesPlugin.Obj.Config.ReputationAveragesEnabled = value;
+                    user.MsgLoc($"reputationTransferEnabled => {value}");
+                    break;
+				case "reputationInterception":
+					CompaniesPlugin.Obj.Config.CompanyReputationInterceptionEnabled = value;
+					user.MsgLoc($"vehicleTransferEnabled => {value}");
+					break;
+				default:
+                    user.MsgLoc($"Valid verbs are 'propertyLimits', 'reputationAverages' or 'reputationInterception'.");
+                    break;
+            }
+
+        }
+
         [ChatSubCommand("Company", "Provides admin-only options for company employee management.", ChatAuthorizationLevel.Admin)]
         public static void Force(User user, Company targetCompany, User targetUser, string verb)
         {
@@ -303,8 +371,15 @@ namespace Eco.Mods.Companies
                     targetCompany.ForceJoin(targetUser);
                     targetCompany.ChangeCeo(targetUser);
                     break;
+                case "demote":
+                    if (!targetCompany.DemoteCeo(targetUser))
+                    {
+                        user.MsgLoc($"Please enter the current CEO of {targetCompany.UILink()} as user!");
+                    };
+
+                    break;
                 default:
-                    user.MsgLoc($"Valid verbs are 'employ', 'fire' or 'promote'.");
+                    user.MsgLoc($"Valid verbs are 'employ', 'fire', 'demote' or 'promote'.");
                     break;
             }
         }

--- a/EcoCompaniesMod/CompanyCommands.cs
+++ b/EcoCompaniesMod/CompanyCommands.cs
@@ -108,7 +108,10 @@ namespace Eco.Mods.Companies
 		public static void Invites(User user)
 		{
 			var company = Companies.Company.GetEmployer(user);
-            if (company != null) { return;  }
+            if (company != null) {
+				user.OkBoxLoc($"You are already bounded to {company.UILink()}...");
+				return;  
+            }
 
             var sb = new LocStringBuilder();
 

--- a/EcoCompaniesMod/CompanyCommands.cs
+++ b/EcoCompaniesMod/CompanyCommands.cs
@@ -97,14 +97,14 @@ namespace Eco.Mods.Companies
             if (targetCompany.InviteList.Remove(user))
             {
 				targetCompany.SendCompanyMessage(Localizer.Do($"{user.UILink()} has declined the invitation to join the company.")); 
-                user.OkBoxLoc($"You reject the invitation to {targetCompany.UILink()}");
+                user.OkBoxLoc($"You rejected the invitation to {targetCompany.UILink()}");
 			} else
             {
 				user.OkBoxLoc($"You aren't invited invitation to {targetCompany.UILink()}");
 			}
 		}
 
-		[ChatSubCommand("Company", "Rejects an invitation for you to a company.", ChatAuthorizationLevel.User)]
+		[ChatSubCommand("Company", "Shows your invitelist.", ChatAuthorizationLevel.User)]
 		public static void Invites(User user)
 		{
 			var company = Companies.Company.GetEmployer(user);

--- a/EcoCompaniesMod/CompanyManager.cs
+++ b/EcoCompaniesMod/CompanyManager.cs
@@ -254,8 +254,8 @@ namespace Eco.Mods.Companies
         }
 		public void InterceptReputationTransfer(ReputationTransfer reputationTransferData, ref PostResult lawPostResult)
 		{			
-			var receiverCompany = Company.GetFromLegalPerson(reputationTransferData.ReputationReceiver);
-			if (receiverCompany != null) // we do not allow anybody to honor the company legal person
+			var receiverIsLegalPerson = Company.GetFromLegalPerson(reputationTransferData.ReputationReceiver);
+			if (receiverIsLegalPerson != null) // we do not allow anybody to honor the company legal person
 			{
 				lawPostResult.Success = false;
 				NotificationManager.ServerMessageToPlayer(
@@ -270,7 +270,7 @@ namespace Eco.Mods.Companies
 
 			if (!CompaniesPlugin.Obj.Config.CompanyReputationInterceptionEnabled) { return;  }
 
-			// we neither allow the employees to reputate internal
+			// we do not allow the employees to reputate internal
 			var senderCompany = Company.GetEmployer(reputationTransferData.ReputationSender);
 			if (senderCompany != null)
 			{
@@ -278,7 +278,7 @@ namespace Eco.Mods.Companies
 				{
 					lawPostResult.Success = false;
 					NotificationManager.ServerMessageToPlayer(
-						Localizer.Do($"{reputationTransferData.ReputationReceiver.UILink()} is (or invited to become a) member of {senderCompany.UILink()} and can't receive any reputation from you."),
+						Localizer.Do($"{reputationTransferData.ReputationReceiver.UILink()} is (or invited to become) a member of {senderCompany.UILink()} and can't receive any reputation from you."),
 						reputationTransferData.ReputationSender,
 						NotificationCategory.Reputation,
 						NotificationStyle.InfoBox
@@ -286,22 +286,24 @@ namespace Eco.Mods.Companies
 
 					return;
 				}
-
-                if (company.InviteList.Contains(reputationTransferData.ReputationSender))
-                {
-					lawPostResult.Success = false;
-					NotificationManager.ServerMessageToPlayer(
-						Localizer.Do($"You are invited to become a member of {company.UILink()} and can't give reputation to anybody in that company."),
-						reputationTransferData.ReputationSender,
-						NotificationCategory.Reputation,
-						NotificationStyle.InfoBox
-					);
-
-					return;
-				}
-				lawPostResult.AddPostEffect(() => company.UpdateLegalPersonReputation());
 			}
 
+			var receiverEmployeer = Company.GetEmployer(reputationTransferData.ReputationReceiver);
+            if (receiverEmployeer != null)
+            {
+                if (Company.IsInvited(reputationTransferData.ReputationSender, receiverEmployeer))
+                {
+                    lawPostResult.Success = false;
+                    NotificationManager.ServerMessageToPlayer(
+                        Localizer.Do($"You are invited to become a member of {receiverEmployeer.UILink()} and can't give reputation to anyone in that company."),
+                        reputationTransferData.ReputationSender,
+                        NotificationCategory.Reputation,
+                        NotificationStyle.InfoBox
+                    );
+
+                    return;
+                }
+			}
 		}
 
         public void InterceptStartHomesteadGameAction(StartHomestead startHomestead, ref PostResult lawPostResult)

--- a/EcoCompaniesMod/CompanyManager.cs
+++ b/EcoCompaniesMod/CompanyManager.cs
@@ -254,8 +254,8 @@ namespace Eco.Mods.Companies
         }
 		public void InterceptReputationTransfer(ReputationTransfer reputationTransferData, ref PostResult lawPostResult)
 		{			
-			Company company = Company.GetFromLegalPerson(reputationTransferData.ReputationReceiver);
-			if (company != null) // we do not allow anybody to honor the company legal person
+			var receiverCompany = Company.GetFromLegalPerson(reputationTransferData.ReputationReceiver);
+			if (receiverCompany != null) // we do not allow anybody to honor the company legal person
 			{
 				lawPostResult.Success = false;
 				NotificationManager.ServerMessageToPlayer(
@@ -271,14 +271,14 @@ namespace Eco.Mods.Companies
 			if (!CompaniesPlugin.Obj.Config.CompanyReputationInterceptionEnabled) { return;  }
 
 			// we neither allow the employees to reputate internal
-			company = Company.GetEmployer(reputationTransferData.ReputationSender);
-			if (company != null)
+			var senderCompany = Company.GetEmployer(reputationTransferData.ReputationSender);
+			if (senderCompany != null)
 			{
-				if (company.IsEmployee(reputationTransferData.ReputationReceiver) || company.InviteList.Contains(reputationTransferData.ReputationReceiver))
+				if (senderCompany.IsEmployee(reputationTransferData.ReputationReceiver) || senderCompany.InviteList.Contains(reputationTransferData.ReputationReceiver))
 				{
 					lawPostResult.Success = false;
 					NotificationManager.ServerMessageToPlayer(
-						Localizer.Do($"{reputationTransferData.ReputationReceiver.UILink()} is (or invited to become a) member of {company.UILink()} and can't receive any reputation from you."),
+						Localizer.Do($"{reputationTransferData.ReputationReceiver.UILink()} is (or invited to become a) member of {senderCompany.UILink()} and can't receive any reputation from you."),
 						reputationTransferData.ReputationSender,
 						NotificationCategory.Reputation,
 						NotificationStyle.InfoBox

--- a/EcoCompaniesMod/Reputation/CompanyReputationGivers.cs
+++ b/EcoCompaniesMod/Reputation/CompanyReputationGivers.cs
@@ -1,0 +1,56 @@
+﻿
+using Eco.Core.PropertyHandling;
+using Eco.Core.Controller;
+
+namespace Eco.Gameplay.Economy.Reputation
+{
+	using System.ComponentModel;
+	using Eco.Shared.Localization;
+	using Eco.Shared.Serialization;
+	using Eco.Shared.Utils;
+	using Range = Eco.Shared.Math.Range;
+
+	[Serialized]
+	public class CompanyPositiveReputationGiver : IGivesReputation
+	{		
+		public LocString MarkedUpName => TextLoc.InfoLightLocStr("AVG Positive Reputation");
+
+		[Serialized] public int Id { get; set; } = RandomUtil.IntValue;
+
+		float IGivesReputation.GivableReputationPerDay => float.PositiveInfinity;
+		public float GivableReputationPerDayPerTarget => float.PositiveInfinity;
+		public Range GivableReputationToSingleTargetTotal => new Range(0, float.PositiveInfinity);
+		int IGivesReputation.DisplayPriority => 2;
+
+		#region IController
+		int controllerID;
+		public ref int ControllerID => ref controllerID;
+
+#pragma warning disable CS0067
+		public event PropertyChangedEventHandler PropertyChanged;
+#pragma warning restore CS0067
+		#endregion
+	}
+
+	[Serialized]
+	public class CompanyNegativeReputationGiver : IGivesReputation
+	{
+		public LocString MarkedUpName => TextLoc.InfoLightLocStr("AVG Negative Reputation");
+
+		[Serialized] public int Id { get; set; } = RandomUtil.IntValue;
+
+		float IGivesReputation.GivableReputationPerDay => float.PositiveInfinity;
+		public float GivableReputationPerDayPerTarget => float.PositiveInfinity;
+		public Range GivableReputationToSingleTargetTotal => new Range(0, float.PositiveInfinity);
+		int IGivesReputation.DisplayPriority => 2;
+
+		#region IController
+		int controllerID;
+		public ref int ControllerID => ref controllerID;
+
+#pragma warning disable CS0067
+		public event PropertyChangedEventHandler PropertyChanged;
+#pragma warning restore CS0067
+		#endregion
+	}
+}


### PR DESCRIPTION
**Reputation**
  - Intercept reputation giving to other employess and from/to invited employees (settings -> CompanyReputationInterceptionEnabled | disabled by default)
  - Deny reputation gains on the legal person by other players (no setting, fixed)
  - Reputation on the legal person (if enabled): All employees reputation as average (negative and positive) (settings -> ReputationAveragesEnabled | disabled by default)
    (if this setting is disabled the reputation relationsship of the legal person will be cleared as 'silent migration' to the new default of 'no reputation possible for the legal person')
- New and changes chatcommands:
  - /company invites -> list alle active invites for the you or a hint that you are already a member of a company ...
  - /company force -> verb 'join' -> simplified code
  - /company force -> verb 'demote' -> demotes the player to a normal employee (mainly for testing/debugging, but useful)
  - /company force -> verb 'promote' -> now removes the promoted player from the basic employee list as the ceo will prepended to this and a promot leaded to wrong plotcounts as the ceo + 'employee-ceo' was counted.
  - /company confiugure -> new and adminonly to enabled/disable features on the fly (which are now: 'propertyLimits', 'reputationAverages' or 'reputationInterception')
- Do not invite residents back to the HQ (which the game should not do at all ...)
 
**Misc**
- Try/ForceJoin and TryFire aren't silent anymore as these actions can be intercepted with laws it makes sense to show a possible rejection by law

**Internal notes**
- RemoveCeo() was added to deduplicate code and does a little check if there is ceo as it also adds the user as employee
- 2 new reputation givers were added and are based on the SpeakingWellOfOthersReputationGiver / unsure if this is the best was, needs more testing.
- IsInvited() as new helper