### PR TITLE
Vehicle transfers & more

### DIFF
--- a/EcoCompaniesMod/CompaniesPlugin.cs
+++ b/EcoCompaniesMod/CompaniesPlugin.cs
@@ -51,7 +51,10 @@ namespace Eco.Mods.Companies
 
         [LocDescription("If enabled, the average repuation from all employees will be given to the legal person.")]
         public bool ReputationAveragesEnabled { get; set; } = false;
-    }
+
+		[LocDescription("If enabled, the company vehicles will be adopted to the legal person on placement.")]
+		public bool VehicleTransfersEnabled { get; set; } = false;
+	}
 
     [Serialized]
     public class CompaniesData : Singleton<CompaniesData>, IStorage
@@ -165,7 +168,7 @@ namespace Eco.Mods.Companies
 
         internal static void OnPostInitialize() {
             Registrars.Get<Company>().ForEach(company => company.RefreshHQPlotsSize());
-            Logger.Debug($"Set correct plot counts for HQs...");
+            Logger.Info($"Set correct plot counts for HQs...");
         }
 
         private void OnBankAccountPermissionsChanged(BankAccount bankAccount)

--- a/EcoCompaniesMod/Company.cs
+++ b/EcoCompaniesMod/Company.cs
@@ -843,7 +843,7 @@ namespace Eco.Mods.Companies
                 {
                     // Logger.Debug($"Vehicle '{obj.Name}' from '{obj.Owner.Name}' transfered to '{Name}'");
 
-                    var _sourceName = obj.Creator?.Name ?? obj.Owner?.Name; // WT #43 -> owners where empty on some objects!? migration?
+                    var _sourceName = obj.Creator?.Name ?? obj.Owner?.Name; // WT #43 -> creators where empty on some objects!? migration?
                     var _newName = obj.Name.Replace(_sourceName, LegalPerson.Name);
                     var _newNameParts = _newName.Split(' ');
 

--- a/EcoCompaniesMod/CompanyManager.cs
+++ b/EcoCompaniesMod/CompanyManager.cs
@@ -344,8 +344,19 @@ namespace Eco.Mods.Companies
                 {
                     Task.Delay(250).ContinueWith(t => FixupHomesteadClaimItems(placeOrPickUpObject.Citizen));
                 });
-            }
-        }
+			}
+			else
+			{
+				var company = Company.GetEmployer(placeOrPickUpObject.Citizen);
+				if (company != null)
+				{
+					lawPostResult.AddPostEffect(() =>
+					{
+						Task.Delay(250).ContinueWith(t => company.UpdateAllVehicles());
+					});
+				}
+			}
+		}
 
         public void HandleDeedDestroyed(Deed deed)
         {


### PR DESCRIPTION
**Vehicle transfer**
  - on join and on placement (config: VehicleTransfersEnabled | disabled by default)
  - vehicle deeds are now filtered at /company claim due to this
  - takeover is possible
  - deeds get a name for the legal person and the deed ID (as I don't want to count the instance of every vehicle for the legal person...)
 
**New and changed chat commands**
- /company status (renamed from config) -> shows status of config options
- /company configure (admin only) -> sets config options on the fly where valid verbs are 'propertyLimits', 'reputationAverages',  'reputationInterception' or 'vehicleTransfers'
- /company list (admin only) -> shows a list of all companies for information gathering